### PR TITLE
Read the error messages from the default Drupal Webform field (#required_error)

### DIFF
--- a/src/Date/index.jsx
+++ b/src/Date/index.jsx
@@ -89,7 +89,7 @@ class Date extends Component {
       hint: () =>
         (<RuleHint
           key={`date_${props.field['#webform_key']}`}
-          hint={WebformUtils.getCustomValue(props.field, 'dateError', props.settings) || site.t('Please enter a valid date.')}
+          hint={WebformUtils.getCustomValue(props.field, 'dateError', props.settings) || WebformUtils.getErrorMessage(props.field, '#required_error') || site.t('Please enter a valid date.')}
         />),
       shouldValidate: field => field.isBlurred && !WebformUtils.isEmpty(field, field.getValue()),
     });
@@ -102,14 +102,14 @@ class Date extends Component {
 
         switch(result.type) {
           case 'before':
-            hint = WebformUtils.getCustomValue(props.field, 'dateBeforeError', props.settings) || site.t('Please enter a date before {{max}}');
+            hint = WebformUtils.getCustomValue(props.field, 'dateBeforeError', props.settings) || WebformUtils.getErrorMessage(props.field, '#required_error') || site.t('Please enter a date before {{max}}');
             break;
           case 'after':
-            hint = WebformUtils.getCustomValue(props.field, 'dateAfterError', props.settings) || site.t('Please enter a date after {{min}}');
+            hint = WebformUtils.getCustomValue(props.field, 'dateAfterError', props.settings) || WebformUtils.getErrorMessage(props.field, '#required_error') || site.t('Please enter a date after {{min}}');
             break;
           default:
           case 'range':
-            hint = WebformUtils.getCustomValue(props.field, 'dateRangeError', props.settings) || site.t('Please enter a date between {{min}} and {{max}}');
+            hint = WebformUtils.getCustomValue(props.field, 'dateRangeError', props.settings) || WebformUtils.getErrorMessage(props.field, '#required_error') || site.t('Please enter a date between {{min}} and {{max}}');
             break;
         }
 

--- a/src/EmailField/index.jsx
+++ b/src/EmailField/index.jsx
@@ -51,13 +51,13 @@ class EmailField extends Component {
     rules.set(`email_${props.field['#webform_key']}`, {
       rule: () => field.isEmpty || validator.isEmail(field.value),
       hint: value =>
-        <RuleHint key={`email_${props.field['#webform_key']}`} hint={WebformUtils.getCustomValue(props.field, 'emailError', props.settings) || site.t('Please enter a valid email.')} tokens={{ value }} />,
+        <RuleHint key={`email_${props.field['#webform_key']}`} hint={WebformUtils.getCustomValue(props.field, 'emailError', props.settings) || WebformUtils.getErrorMessage(field, '#required_error') || site.t('Please enter a valid email.')} tokens={{ value }} />,
       shouldValidate: () => field.isBlurred && !field.isEmpty,
     });
     rules.set(`email_neverbounce_${props.field['#webform_key']}`, {
       rule: () => field.isEmpty || field.lookupSuccessful,
       hint: () =>
-        <RuleHint key={`email_neverbounce_${props.field['#webform_key']}`} hint={WebformUtils.getCustomValue(props.field, 'neverBounceError', props.settings) || site.t('Please enter a valid email.')} />,
+        <RuleHint key={`email_neverbounce_${props.field['#webform_key']}`} hint={WebformUtils.getCustomValue(props.field, 'neverBounceError', props.settings) || WebformUtils.getErrorMessage(props.field, '#required_error') || site.t('Please enter a valid email.')} />,
       shouldValidate: () => field.isBlurred && !field.isEmpty && validator.isEmail(field.value),
     });
 

--- a/src/IBAN/index.jsx
+++ b/src/IBAN/index.jsx
@@ -30,7 +30,7 @@ class IBAN extends Component {
     rules.set(`iban_${props.field['#webform_key']}`, {
       rule: value => isValidIBAN(value),
       hint: () =>
-        <RuleHint key={`iban_${props.field['#webform_key']}`} hint={WebformUtils.getCustomValue(props.field, 'ibanError', props.settings) || site.t('Please enter a valid IBAN.')} />,
+        <RuleHint key={`iban_${props.field['#webform_key']}`} hint={WebformUtils.getCustomValue(props.field, 'ibanError', props.settings) || WebformUtils.getErrorMessage(props.field, '#required_error') || site.t('Please enter a valid IBAN.')} />,
       shouldValidate: field => field.isBlurred,
     });
   }

--- a/src/Observables/Field.jsx
+++ b/src/Observables/Field.jsx
@@ -85,7 +85,7 @@ class Field {
       hint: value =>
         (<RuleHint
           key={`req_${this.key}`}
-          hint={WebformUtils.getCustomValue(this.element, 'requiredError', this.formStore.form.settings) || site.t('This field is required')}
+          hint={WebformUtils.getCustomValue(this.element, 'requiredError', this.formStore.form.settings) || WebformUtils.getErrorMessage(element, '#required_error') || site.t('This field is required')}
           tokens={{
             value,
             name: this.element['#title'],
@@ -100,7 +100,7 @@ class Field {
         rule: (value = '') => new RegExp(pattern).test(value) || this.isEmpty,
         hint: (value) => {
           const patternError = WebformUtils.getCustomValue(this.element, 'patternError', this.formStore.form.settings);
-          const populatedPatternError = getNested(() => this.formStore.form.settings.custom_elements.patternError['#options'][patternError], this.element['#patternError'] || site.t('Please enter a valid value.'));
+          const populatedPatternError = getNested(() => this.formStore.form.settings.custom_elements.patternError['#options'][patternError], this.element['#patternError'] || WebformUtils.getErrorMessage(element, '#required_error') || site.t('Please enter a valid value.'));
           return <RuleHint key={`pattern_${this.key}`} hint={populatedPatternError} tokens={{ value }} />;
         },
         shouldValidate: field => field.isBlurred && WebformUtils.validateRule(rules.get(`${supportedActions.required}_${this.key}`), field),

--- a/src/Relation/index.jsx
+++ b/src/Relation/index.jsx
@@ -106,7 +106,7 @@ class Relation extends Component {
         onBlur={this.props.onBlur}
       >
         {field.lookupSent && !field.lookupSuccessful && (
-          <RuleHint component={<ValidationMessage />} key={`relation_${this.props.field['#webform_key']}`} hint={WebformUtils.getCustomValue(this.props.field, 'relationError', this.props.settings) || site.t('We don\'t recognise this combination of relation number and postal code. Please check again, or proceed anyway.')} />
+          <RuleHint component={<ValidationMessage />} key={`relation_${this.props.field['#webform_key']}`} hint={WebformUtils.getCustomValue(this.props.field, 'relationError', this.props.settings) || WebformUtils.getErrorMessage(this.props.field, '#required_error') || site.t('We don\'t recognise this combination of relation number and postal code. Please check again, or proceed anyway.')} />
         )}
       </Fieldset>
     );

--- a/src/WebformUtils.js
+++ b/src/WebformUtils.js
@@ -14,6 +14,11 @@ class WebformUtils {
     return getNested(() => settings.custom_elements[key]['#default_value'], null);
   }
 
+  static getErrorMessage(field, key) {
+    const errorMessage = getNested(() => field[key], null);
+    return errorMessage && errorMessage !== '' ? errorMessage : null;
+  }
+
   static validateRule(rule, field, force = false) {
     if(!rule) return true;
     else if(force || !rule.shouldValidate || rule.shouldValidate(field)) {


### PR DESCRIPTION
Hi,
I've added the possibility to use the default error messages  from the Drupal webforms module.

Please let me know if I implemented this the right way, and if we can merge this into the module.

Cheers,
Matthijs